### PR TITLE
chore: Bump version to 1.3.0 for Bronze Tier compliance release

### DIFF
--- a/custom_components/SimpleChores/diagnostics.py
+++ b/custom_components/SimpleChores/diagnostics.py
@@ -55,7 +55,7 @@ async def async_get_config_entry_diagnostics(
         approvals_by_status[status] = approvals_by_status.get(status, 0) + 1
 
     return {
-        "integration_version": "1.2.1",
+        "integration_version": "1.3.0",
         "config_data": {
             "kids": entry.data.get("kids", ""),
             "use_todo": entry.data.get("use_todo", True),

--- a/custom_components/SimpleChores/manifest.json
+++ b/custom_components/SimpleChores/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "simplechores",
   "name": "SimpleChores",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "documentation": "https://github.com/mor-dar/SimpleChores",
   "issue_tracker": "https://github.com/mor-dar/SimpleChores/issues",
   "dependencies": [],

--- a/custom_components/SimpleChores/quality_scale.yaml
+++ b/custom_components/SimpleChores/quality_scale.yaml
@@ -155,4 +155,4 @@ exemptions:
 
 # Last Updated
 last_updated: "2025-01-22"
-version: "1.2.1"
+version: "1.3.0"


### PR DESCRIPTION
## Summary
Version bump to 1.3.0 for the major Bronze Tier compliance release.

## Changes
- 📦 **manifest.json**: Updated version to 1.3.0
- 🔍 **diagnostics.py**: Updated integration_version to 1.3.0  
- 📋 **quality_scale.yaml**: Updated version tracking to 1.3.0

## Release Type: Minor (1.3.0)
This is a **minor version bump** because:
- ✨ **New Features**: Comprehensive diagnostics support, quality scale tracking
- 🔧 **Major Improvements**: Bronze Tier compliance, enhanced error handling
- 🏆 **Significant Milestone**: Home Assistant integration best practices compliance
- 🔒 **Backward Compatible**: No breaking changes

## What's New in v1.3.0
- 🏆 **Home Assistant Bronze Tier Compliance** (6/6 requirements met)
- 🔧 **Comprehensive Error Handling** with ConfigEntryNotReady pattern
- 📝 **Complete Type Annotations** throughout codebase
- 🚨 **Enhanced Service Exception Handling** with clear error messages
- ⚡ **Improved Async Patterns** with proper blocking service calls
- 🔍 **Diagnostic Support** for troubleshooting and monitoring
- 📊 **Quality Scale Tracking** for continuous improvement

Ready for release tagging and GitHub release creation.

🤖 Generated with [Claude Code](https://claude.ai/code)