### PR TITLE
fix: Add consistent SimpleChores prefix to all entity names

### DIFF
--- a/custom_components/SimpleChores/button.py
+++ b/custom_components/SimpleChores/button.py
@@ -47,7 +47,7 @@ class SimpleChoresCreateChoreButton(ButtonEntity):
         self._coord = coord
         self._hass = hass
         self._attr_unique_id = f"{DOMAIN}_create_chore_button"
-        self._attr_name = "Create Chore"
+        self._attr_name = "SimpleChores Create Chore"
 
     async def async_press(self) -> None:
         import logging
@@ -120,9 +120,9 @@ class SimpleChoresRewardButton(ButtonEntity):
         reward = coord.get_reward(reward_id)
         self._attr_unique_id = f"{DOMAIN}_reward_{reward_id}_{kid_id}"
         if reward:
-            self._attr_name = f"{reward.title} ({kid_id.capitalize()}) - {reward.cost}pts"
+            self._attr_name = f"SimpleChores {reward.title} ({kid_id.capitalize()}) - {reward.cost}pts"
         else:
-            self._attr_name = f"Unknown Reward ({kid_id.capitalize()})"
+            self._attr_name = f"SimpleChores Unknown Reward ({kid_id.capitalize()})"
 
     @property
     def available(self) -> bool:
@@ -152,7 +152,7 @@ class SimpleChoresCreateRecurringButton(ButtonEntity):
         self._coord = coord
         self._hass = hass
         self._attr_unique_id = f"{DOMAIN}_create_recurring_button"
-        self._attr_name = "Create Recurring Chore"
+        self._attr_name = "SimpleChores Create Recurring Chore"
 
     async def async_press(self) -> None:
         import logging
@@ -240,7 +240,7 @@ class SimpleChoresGenerateDailyButton(ButtonEntity):
         self._coord = coord
         self._hass = hass
         self._attr_unique_id = f"{DOMAIN}_generate_daily_button"
-        self._attr_name = "Generate Today's Chores"
+        self._attr_name = "SimpleChores Generate Today's Chores"
 
     async def async_press(self) -> None:
         import logging
@@ -264,7 +264,7 @@ class SimpleChoresApprovalStatusButton(ButtonEntity):
         self._coord = coord
         self._hass = hass
         self._attr_unique_id = f"{DOMAIN}_approval_status_button"
-        self._attr_name = "Show Pending Approvals"
+        self._attr_name = "SimpleChores Show Pending Approvals"
         # Store reference in coordinator for updates
         if not hasattr(coord, '_approval_buttons'):
             coord._approval_buttons = []
@@ -277,8 +277,8 @@ class SimpleChoresApprovalStatusButton(ButtonEntity):
             import logging
             _LOGGER = logging.getLogger(__name__)
             _LOGGER.debug(f"SimpleChores: Approval button name check - pending count: {pending_count}")
-            return f"Pending Approvals ({pending_count})"
-        return "Pending Approvals (0)"
+            return f"SimpleChores Pending Approvals ({pending_count})"
+        return "SimpleChores Pending Approvals (0)"
 
     @property
     def available(self) -> bool:
@@ -309,7 +309,7 @@ class SimpleChoresResetRejectedButton(ButtonEntity):
         self._coord = coord
         self._hass = hass
         self._attr_unique_id = f"{DOMAIN}_reset_rejected_button"
-        self._attr_name = "Reset Rejected Chores"
+        self._attr_name = "SimpleChores Reset Rejected Chores"
 
     async def async_press(self) -> None:
         import logging

--- a/custom_components/SimpleChores/sensor.py
+++ b/custom_components/SimpleChores/sensor.py
@@ -32,7 +32,7 @@ class SimpleChoresWeekSensor(SensorEntity):
         self._coord = coord
         self._kid_id = kid_id
         self._attr_unique_id = f"{DOMAIN}_{kid_id}_points_week"
-        self._attr_name = f"{kid_id.capitalize()} Points (This Week)"
+        self._attr_name = f"SimpleChores {kid_id.capitalize()} Points (This Week)"
 
     @property
     def native_value(self):
@@ -53,7 +53,7 @@ class SimpleChoresTotalSensor(SensorEntity):
         self._coord = coord
         self._kid_id = kid_id
         self._attr_unique_id = f"{DOMAIN}_{kid_id}_points_total"
-        self._attr_name = f"{kid_id.capitalize()} Points (Total Earned)"
+        self._attr_name = f"SimpleChores {kid_id.capitalize()} Points (Total Earned)"
         self._attr_icon = "mdi:star-circle-outline"
 
     @property
@@ -73,7 +73,7 @@ class SimpleChoresPendingApprovalsSensor(SensorEntity):
     def __init__(self, coord: SimpleChoresCoordinator):
         self._coord = coord
         self._attr_unique_id = f"{DOMAIN}_pending_approvals"
-        self._attr_name = "Pending Chore Approvals"
+        self._attr_name = "SimpleChores Pending Chore Approvals"
         self._attr_icon = "mdi:clipboard-check-multiple"
         # Store reference in coordinator for updates
         if not hasattr(coord, '_approval_sensors'):

--- a/custom_components/SimpleChores/text.py
+++ b/custom_components/SimpleChores/text.py
@@ -39,7 +39,7 @@ class SimpleChoresChoreTitle(TextEntity):
     def __init__(self, coord: SimpleChoresCoordinator):
         self._coord = coord
         self._attr_unique_id = f"{DOMAIN}_chore_title_input"
-        self._attr_name = "Chore Title"
+        self._attr_name = "SimpleChores Chore Title"
         self._attr_native_value = "Enter chore name"
 
     @property
@@ -58,7 +58,7 @@ class SimpleChoresChorePoints(TextEntity):
     def __init__(self, coord: SimpleChoresCoordinator):
         self._coord = coord
         self._attr_unique_id = f"{DOMAIN}_chore_points_input"
-        self._attr_name = "Chore Points"
+        self._attr_name = "SimpleChores Chore Points"
         self._attr_native_value = "5"
 
     @property
@@ -77,7 +77,7 @@ class SimpleChoresChoreKid(TextEntity):
         self._coord = coord
         self._kids = kids
         self._attr_unique_id = f"{DOMAIN}_chore_kid_input"
-        self._attr_name = "Kid"
+        self._attr_name = "SimpleChores Kid"
         self._attr_native_value = kids[0] if kids else "noam"
 
     @property
@@ -100,7 +100,7 @@ class SimpleChoresRecurringTitle(TextEntity):
     def __init__(self, coord: SimpleChoresCoordinator):
         self._coord = coord
         self._attr_unique_id = f"{DOMAIN}_recurring_title_input"
-        self._attr_name = "Recurring Chore Title"
+        self._attr_name = "SimpleChores Recurring Chore Title"
         self._attr_native_value = "Brush teeth"
 
     @property
@@ -119,7 +119,7 @@ class SimpleChoresRecurringPoints(TextEntity):
     def __init__(self, coord: SimpleChoresCoordinator):
         self._coord = coord
         self._attr_unique_id = f"{DOMAIN}_recurring_points_input"
-        self._attr_name = "Recurring Chore Points"
+        self._attr_name = "SimpleChores Recurring Chore Points"
         self._attr_native_value = "2"
 
     @property
@@ -138,7 +138,7 @@ class SimpleChoresRecurringKid(TextEntity):
         self._coord = coord
         self._kids = kids
         self._attr_unique_id = f"{DOMAIN}_recurring_kid_input"
-        self._attr_name = "Recurring Chore Kid"
+        self._attr_name = "SimpleChores Recurring Chore Kid"
         self._attr_native_value = kids[0] if kids else "noam"
 
     @property
@@ -157,7 +157,7 @@ class SimpleChoresRecurringSchedule(TextEntity):
     def __init__(self, coord: SimpleChoresCoordinator):
         self._coord = coord
         self._attr_unique_id = f"{DOMAIN}_recurring_schedule_input"
-        self._attr_name = "Schedule Type"
+        self._attr_name = "SimpleChores Schedule Type"
         self._attr_native_value = "daily"
 
     @property
@@ -177,7 +177,7 @@ class SimpleChoresRecurringDay(TextEntity):
     def __init__(self, coord: SimpleChoresCoordinator):
         self._coord = coord
         self._attr_unique_id = f"{DOMAIN}_recurring_day_input"
-        self._attr_name = "Day of Week (0=Mon, 6=Sun)"
+        self._attr_name = "SimpleChores Day of Week (0=Mon, 6=Sun)"
         self._attr_native_value = "0"
 
     @property

--- a/fixed_dashboard.yaml
+++ b/fixed_dashboard.yaml
@@ -1,0 +1,121 @@
+title: SimpleChores Dashboard
+path: simplechores
+icon: mdi:clipboard-check
+cards:
+  # Kids Points Section
+  - type: vertical-stack
+    title: Points Balance
+    cards:
+      - type: entities
+        title: Current Points
+        entities:
+          - entity: number.simplechores_lior_points
+            name: "Lior Points"
+          - entity: number.simplechores_noam_points
+            name: "Noam Points"
+
+      - type: entities
+        title: Weekly & Total Points
+        entities:
+          - entity: sensor.simplechores_lior_points_week
+            name: "Lior This Week"
+          - entity: sensor.simplechores_lior_points_total
+            name: "Lior Total Earned"
+          - entity: sensor.simplechores_noam_points_week
+            name: "Noam This Week"
+          - entity: sensor.simplechores_noam_points_total
+            name: "Noam Total Earned"
+
+  # Chore Creation Section
+  - type: vertical-stack
+    title: Create Chores
+    cards:
+      - type: entities
+        title: Chore Inputs
+        entities:
+          - entity: text.simplechores_chore_title_input
+            name: "Chore Title"
+          - entity: text.simplechores_chore_points_input
+            name: "Points"
+          - entity: text.simplechores_chore_kid_input
+            name: "Kid"
+
+      - type: entities
+        title: Chore Actions
+        entities:
+          - entity: button.simplechores_create_chore
+            name: "Create Chore"
+            tap_action:
+              action: call-service
+              service: button.press
+              target:
+                entity_id: button.simplechores_create_chore
+
+  # Recurring Chores Section
+  - type: vertical-stack
+    title: Recurring Chores
+    cards:
+      - type: entities
+        title: Recurring Inputs
+        entities:
+          - entity: text.simplechores_recurring_title_input
+            name: "Title"
+          - entity: text.simplechores_recurring_points_input
+            name: "Points"
+          - entity: text.simplechores_recurring_kid_input
+            name: "Kid"
+          - entity: text.simplechores_recurring_schedule_input
+            name: "Schedule (daily/weekly)"
+          - entity: text.simplechores_recurring_day_input
+            name: "Day (0=Mon...6=Sun)"
+
+      - type: entities
+        title: Recurring Actions
+        entities:
+          - entity: button.simplechores_create_recurring
+            name: "Create Recurring Chore"
+          - entity: button.generate_today_s_chores
+            name: "Generate Today's Chores"
+
+  # Approvals Section
+  - type: vertical-stack
+    title: Pending Approvals
+    cards:
+      - type: entities
+        entities:
+          - entity: sensor.simplechores_pending_approvals
+            name: "Pending Approvals Count"
+          - entity: button.simplechores_pending_approvals
+            name: "Show Pending Approvals"
+          - entity: button.simplechores_reset_rejected
+            name: "Reset Rejected Chores"
+
+  # Rewards Section
+  - type: vertical-stack
+    title: Rewards
+    cards:
+      # Lior Rewards
+      - type: entities
+        title: Lior Rewards
+        entities:
+          - entity: button.simplechores_reward_movie_night_lior
+            name: "Movie Night (20pts)"
+          - entity: button.simplechores_reward_extra_allowance_lior
+            name: "Extra Allowance (25pts)"
+          - entity: button.simplechores_reward_park_trip_lior
+            name: "Park Trip (30pts)"
+          - entity: button.simplechores_reward_ice_cream_lior
+            name: "Ice Cream (15pts)"
+
+      # Noam Rewards
+      - type: entities
+        title: Noam Rewards
+        entities:
+          - entity: button.simplechores_reward_movie_night_noam
+            name: "Movie Night (20pts)"
+          - entity: button.simplechores_reward_extra_allowance_noam
+            name: "Extra Allowance (25pts)"
+          - entity: button.simplechores_reward_park_trip_noam
+            name: "Park Trip (30pts)"
+          - entity: button.simplechores_reward_ice_cream_noam
+            name: "Ice Cream (15pts)"

--- a/tests/test_platforms.py
+++ b/tests/test_platforms.py
@@ -160,7 +160,7 @@ class TestSimpleChoresWeekSensor:
         assert sensor._coord == mock_coordinator_with_ledger
         assert sensor._kid_id == "alice"
         assert sensor._attr_unique_id == f"{DOMAIN}_alice_points_week"
-        assert sensor._attr_name == "Alice Points (This Week)"
+        assert sensor._attr_name == "SimpleChores Alice Points (This Week)"
 
     def test_week_sensor_native_value(self, mock_coordinator_with_ledger):
         """Test week sensor native value calculation."""
@@ -211,7 +211,7 @@ class TestSimpleChoresText:
 
         assert entity._coord == mock_coordinator
         assert entity._attr_unique_id == f"{DOMAIN}_chore_title_input"
-        assert entity._attr_name == "Chore Title"
+        assert entity._attr_name == "SimpleChores Chore Title"
         assert entity._attr_native_value == "Enter chore name"
         assert entity._attr_icon == "mdi:text"
         assert entity._attr_native_min == 1
@@ -274,7 +274,7 @@ class TestSimpleChoresButton:
         assert button._coord == mock_coordinator
         assert button._hass == mock_hass
         assert button._attr_unique_id == f"{DOMAIN}_create_chore_button"
-        assert button._attr_name == "Create Chore"
+        assert button._attr_name == "SimpleChores Create Chore"
         assert button._attr_icon == "mdi:plus-circle"
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Fixes inconsistent entity naming where entities had mixed prefixes (some with simplechores_, others without)
- All button, text, and sensor entities now use "SimpleChores" prefix in their display names
- This ensures consistent entity IDs like `button.simplechores_create_chore`, `text.simplechores_chore_title`
- Updated corresponding tests to match new naming convention

## What Changed
- **Button entities**: Added "SimpleChores" prefix to all button names
- **Text entities**: Added "SimpleChores" prefix to all input helper names  
- **Sensor entities**: Added "SimpleChores" prefix to all sensor names
- **Tests**: Updated assertions to match new naming

## Impact
- **Breaking Change**: Users will need to restart Home Assistant to get new entity names
- Old inconsistent entity names may need manual cleanup in HA entity registry
- Dashboard configurations will need updating to use new entity names
- Fixes user confusion about mixed entity naming patterns

## Test Plan
- [x] All platform tests pass with updated naming
- [x] Entity creation and functionality unchanged
- [x] No breaking changes to unique_id patterns (data preserved)

🤖 Generated with [Claude Code](https://claude.ai/code)