### PR TITLE
chore: Bump version to 1.3.1

### DIFF
--- a/custom_components/SimpleChores/manifest.json
+++ b/custom_components/SimpleChores/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "simplechores",
   "name": "SimpleChores",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "documentation": "https://github.com/mor-dar/SimpleChores",
   "issue_tracker": "https://github.com/mor-dar/SimpleChores/issues",
   "dependencies": [],


### PR DESCRIPTION
Version bump to 1.3.1 for entity naming consistency patch release