### PR TITLE
chore: Bump version to 1.4.5 for approval button fix release

### DIFF
--- a/custom_components/SimpleChores/manifest.json
+++ b/custom_components/SimpleChores/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "simplechores",
   "name": "SimpleChores",
-  "version": "1.4.4",
+  "version": "1.4.5",
   "documentation": "https://github.com/mor-dar/SimpleChores",
   "issue_tracker": "https://github.com/mor-dar/SimpleChores/issues",
   "dependencies": [],


### PR DESCRIPTION
Version bump for patch release 1.4.5 that includes the critical approval button fix from PR #19.

This release fixes the issue where chore claim buttons became unavailable but no approve/reject buttons appeared for parents.

🤖 Generated with [Claude Code](https://claude.ai/code)